### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,29 +6,29 @@
 # Class (KEYWORD1)
 #######################################
 
-TheThingsNetwork        KEYWORD1
+TheThingsNetwork	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-showStatus              KEYWORD2
-onMessage               KEYWORD2
-provision               KEYWORD2
-join                    KEYWORD2
-personalize             KEYWORD2
-sendBytes               KEYWORD2
-poll                    KEYWORD2
+showStatus	KEYWORD2
+onMessage	KEYWORD2
+provision	KEYWORD2
+join	KEYWORD2
+personalize	KEYWORD2
+sendBytes	KEYWORD2
+poll	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TTN_DEFAULT_WAIT_TIME   LITERAL1
-TTN_DEFAULT_SF          LITERAL1
-TTN_DEFAULT_FSB         LITERAL1
-TTN_ADR_SUPPORTED       LITERAL1
-TTN_PWRIDX_868          LITERAL1
-TTN_PWRIDX_915          LITERAL1
-TTN_FP_EU868            LITERAL1
-TTN_FP_EU915            LITERAL1
+TTN_DEFAULT_WAIT_TIME	LITERAL1
+TTN_DEFAULT_SF	LITERAL1
+TTN_DEFAULT_FSB	LITERAL1
+TTN_ADR_SUPPORTED	LITERAL1
+TTN_PWRIDX_868	LITERAL1
+TTN_PWRIDX_915	LITERAL1
+TTN_FP_EU868	LITERAL1
+TTN_FP_EU915	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords